### PR TITLE
fix: deployment명이 잘못 작성되어 있는 부분 수정.

### DIFF
--- a/.github/workflows/kubeconfig.yaml
+++ b/.github/workflows/kubeconfig.yaml
@@ -74,7 +74,10 @@ jobs:
 
                   if [ "$BRANCH_NAME" = "main" ]; then
                     echo "Restarting deployment for main branch"
-                    kubectl rollout restart deployment backend-dev-back -n prod
+                    kubectl rollout restart deployment backend-prod -n prod
+                    kubectl rollout restart deployment nextjs-prod-web -n prod
+                    kubectl rollout restart deployment postgresql-prod -n prod
+                    
                   else
                     echo "Restarting deployment for feature branch"
                     kubectl rollout restart deployment backend-dev-back -n dev-back


### PR DESCRIPTION
워크플로우에서 디플로이먼트 명이 dev-back부분으로 되어있어서 main브랜치에 병합할때 오류가 발생했습니다.
main브랜치에서는 prod namespace를 사용하여, 모든 디플로이먼트가 prod이름을 가져야합니다.
 kubectl get pods
NAME                              READY   STATUS    RESTARTS   AGE
backend-prod-7fb5c59786-7cjck     1/1     Running   0          14h
nextjs-prod-web-d9dfb8864-66grj   1/1     Running   0          8d
nextjs-prod-web-d9dfb8864-b89rv   1/1     Running   0          14h
postgresql-prod-0                 1/1     Running   0          8d
redis-prod-master-0               1/1     Running   0          8d
redis-prod-replicas-0             1/1     Running   0          8d

그래서 해당부분 수정완료했습니다.