### PR TITLE
Feature/today problem

### DIFF
--- a/src/main/java/code/rice/bowl/spaghetti/InitDataLoader.java
+++ b/src/main/java/code/rice/bowl/spaghetti/InitDataLoader.java
@@ -2,6 +2,7 @@ package code.rice.bowl.spaghetti;
 
 import code.rice.bowl.spaghetti.entity.*;
 import code.rice.bowl.spaghetti.repository.*;
+import code.rice.bowl.spaghetti.utils.QuestionType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -60,7 +61,7 @@ public class InitDataLoader implements CommandLineRunner {
                     .description(desc)
                     .answer("2")
                     .point(100)
-                    .questionType(Problem.QuestionType.multiple_choice)
+                    .questionType(QuestionType.MULTIPLE_CHOICE)
                     .category(defaultCat)
                     .user(testUser)
                     .build();

--- a/src/main/java/code/rice/bowl/spaghetti/controller/UserController.java
+++ b/src/main/java/code/rice/bowl/spaghetti/controller/UserController.java
@@ -21,6 +21,7 @@ public class UserController {
     private final UserProgressService userProgressService;
     private final TodayProblemService todayProblemService;
     private final StreakService streakService;
+    private final UserProblemHistoryService userProblemHistoryService;
 
     // 현재 로그인한 사용자가 자신의 정보를 요청할 때
     @GetMapping("")
@@ -50,6 +51,12 @@ public class UserController {
     @GetMapping("/streak")
     public ResponseEntity<?> getStreak(@AuthenticationPrincipal(expression = "username") String email) {
         return ResponseEntity.ok(streakService.getStreak(email));
+    }
+
+    // 사용자의 제출 기록을 요청.
+    @GetMapping("/history")
+    public ResponseEntity<?> getSubmitHistory(@AuthenticationPrincipal(expression = "username") String email) {
+        return ResponseEntity.ok(userProblemHistoryService.getHistoriesByUser(email));
     }
 
     // 그 외 일반적으로 타인의 정보를 요청할 때 -> 나중에 필요할 듯.

--- a/src/main/java/code/rice/bowl/spaghetti/controller/crud/UserProblemHistoryCrudController.java
+++ b/src/main/java/code/rice/bowl/spaghetti/controller/crud/UserProblemHistoryCrudController.java
@@ -23,7 +23,7 @@ public class UserProblemHistoryCrudController {
     @GetMapping("/user/{userId}")
     @Operation(summary = "문제풀이 기록 조회")
     public ResponseEntity<List<UserProblemHistoryResponse>> getUserHistories(@PathVariable Long userId) {
-        return ResponseEntity.ok(historyService.getHistoriesByUserId(userId));
+        return ResponseEntity.ok(historyService.getHistoriesByUser(userId));
     }
 
     // 프로필 화면 통계 제공 (푼 문제 수, 맞은 문제 수, 정답률)

--- a/src/main/java/code/rice/bowl/spaghetti/dto/problem/ProblemDetailResponse.java
+++ b/src/main/java/code/rice/bowl/spaghetti/dto/problem/ProblemDetailResponse.java
@@ -17,4 +17,6 @@ public class ProblemDetailResponse {
     QuestionType type;
     String title;
     JsonNode description;
+    String answer;
+    int point;
 }

--- a/src/main/java/code/rice/bowl/spaghetti/dto/problem/ProblemDetailResponse.java
+++ b/src/main/java/code/rice/bowl/spaghetti/dto/problem/ProblemDetailResponse.java
@@ -1,5 +1,6 @@
 package code.rice.bowl.spaghetti.dto.problem;
 
+import code.rice.bowl.spaghetti.utils.QuestionType;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +14,7 @@ import lombok.Setter;
 @Builder
 public class ProblemDetailResponse {
     Long problemId;
+    QuestionType type;
     String title;
     JsonNode description;
 }

--- a/src/main/java/code/rice/bowl/spaghetti/dto/problem/ProblemRequest.java
+++ b/src/main/java/code/rice/bowl/spaghetti/dto/problem/ProblemRequest.java
@@ -1,6 +1,7 @@
 package code.rice.bowl.spaghetti.dto.problem;
 
-import code.rice.bowl.spaghetti.entity.Problem.QuestionType;
+
+import code.rice.bowl.spaghetti.utils.QuestionType;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;

--- a/src/main/java/code/rice/bowl/spaghetti/dto/problem/ProblemResponse.java
+++ b/src/main/java/code/rice/bowl/spaghetti/dto/problem/ProblemResponse.java
@@ -1,6 +1,7 @@
 package code.rice.bowl.spaghetti.dto.problem;
 
-import code.rice.bowl.spaghetti.entity.Problem.QuestionType;
+
+import code.rice.bowl.spaghetti.utils.QuestionType;
 import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/code/rice/bowl/spaghetti/entity/NotSolveProblem.java
+++ b/src/main/java/code/rice/bowl/spaghetti/entity/NotSolveProblem.java
@@ -1,0 +1,25 @@
+package code.rice.bowl.spaghetti.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "not_solve_problem")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotSolveProblem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long notSolveProblemId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "problem_id")
+    private Problem problem;
+}

--- a/src/main/java/code/rice/bowl/spaghetti/entity/Problem.java
+++ b/src/main/java/code/rice/bowl/spaghetti/entity/Problem.java
@@ -1,6 +1,8 @@
 package code.rice.bowl.spaghetti.entity;
 
 import code.rice.bowl.spaghetti.utils.JsonNodeConverter;
+import code.rice.bowl.spaghetti.utils.QuestionType;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.persistence.*;
 import lombok.*;
@@ -58,9 +60,4 @@ public class Problem {
     @Builder.Default
     private int point = 10;
 
-    public enum QuestionType {
-        multiple_choice,
-        short_answer,
-        true_false
-    }
 }

--- a/src/main/java/code/rice/bowl/spaghetti/entity/User.java
+++ b/src/main/java/code/rice/bowl/spaghetti/entity/User.java
@@ -54,6 +54,10 @@ public class User {
     @Builder.Default
     private List<TodayProblem> todayProblems = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<NotSolveProblem> notSolveAiProblems = new ArrayList<>();
+
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @Setter(AccessLevel.NONE)
     private Streak streak;

--- a/src/main/java/code/rice/bowl/spaghetti/mapper/ProblemMapper.java
+++ b/src/main/java/code/rice/bowl/spaghetti/mapper/ProblemMapper.java
@@ -6,8 +6,6 @@ import code.rice.bowl.spaghetti.dto.problem.ProblemResponse;
 import code.rice.bowl.spaghetti.dto.problem.ProblemSimpleResponse;
 import code.rice.bowl.spaghetti.entity.Category;
 import code.rice.bowl.spaghetti.entity.Problem;
-// import code.rice.bowl.spaghetti.entity.Problem.DifficultyLevel;
-import code.rice.bowl.spaghetti.entity.Problem.QuestionType;
 import code.rice.bowl.spaghetti.entity.Topic;
 import code.rice.bowl.spaghetti.entity.User;
 
@@ -63,6 +61,7 @@ public class ProblemMapper {
     public static ProblemDetailResponse toDetailDto(Problem problem) {
         return ProblemDetailResponse.builder()
                 .title(problem.getTitle())
+                .type(problem.getQuestionType())
                 .problemId(problem.getProblemId())
                 .description(problem.getDescription())
                 .build();

--- a/src/main/java/code/rice/bowl/spaghetti/mapper/ProblemMapper.java
+++ b/src/main/java/code/rice/bowl/spaghetti/mapper/ProblemMapper.java
@@ -64,6 +64,8 @@ public class ProblemMapper {
                 .type(problem.getQuestionType())
                 .problemId(problem.getProblemId())
                 .description(problem.getDescription())
+                .answer(problem.getAnswer())
+                .point(problem.getPoint())
                 .build();
     }
 }

--- a/src/main/java/code/rice/bowl/spaghetti/service/CourseService.java
+++ b/src/main/java/code/rice/bowl/spaghetti/service/CourseService.java
@@ -1,6 +1,7 @@
 package code.rice.bowl.spaghetti.service;
 
 import code.rice.bowl.spaghetti.entity.Course;
+import code.rice.bowl.spaghetti.entity.Problem;
 import code.rice.bowl.spaghetti.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,4 +22,11 @@ public class CourseService {
     public Optional<Course> getCourseNullable(Long id) {
         return courseRepository.findById(id);
     }
+
+    public void addCourse(Problem problem) {
+        courseRepository.save(Course.builder()
+                        .problem(problem)
+                        .build());
+    }
+
 }

--- a/src/main/java/code/rice/bowl/spaghetti/service/CourseService.java
+++ b/src/main/java/code/rice/bowl/spaghetti/service/CourseService.java
@@ -1,10 +1,11 @@
 package code.rice.bowl.spaghetti.service;
 
 import code.rice.bowl.spaghetti.entity.Course;
-import code.rice.bowl.spaghetti.exception.NotFoundException;
 import code.rice.bowl.spaghetti.repository.CourseRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -12,8 +13,12 @@ public class CourseService {
 
     private final CourseRepository courseRepository;
 
-    public Course getCourse(Long id) {
-        return courseRepository.findById(id)
-                .orElseThrow(() -> new NotFoundException("Course Not found : " + id));
+    /**
+     * 조회한 문제가 없더라도 에러 발생 X.
+     * @param id 조회할 문제 번호.
+     * @return  Course or None.
+     */
+    public Optional<Course> getCourseNullable(Long id) {
+        return courseRepository.findById(id);
     }
 }

--- a/src/main/java/code/rice/bowl/spaghetti/service/GradingService.java
+++ b/src/main/java/code/rice/bowl/spaghetti/service/GradingService.java
@@ -45,6 +45,7 @@ public class GradingService {
                 .equals(normalize(problem.getAnswer()));
         int point = isCorrect ? problem.getPoint() : 0;
 
+        // 1. 장답 체크.
         if (isCorrect) {
             user.addPoints(point);
             userRepository.save(user);

--- a/src/main/java/code/rice/bowl/spaghetti/service/ProblemService.java
+++ b/src/main/java/code/rice/bowl/spaghetti/service/ProblemService.java
@@ -29,6 +29,7 @@ public class ProblemService {
     private final TopicRepository topicRepository;
     private final CategoryRepository categoryRepository;
     private final UserRepository userRepository;
+    private final CourseService courseService;
 
     @Transactional
     public ProblemResponse create(ProblemRequest dto) {
@@ -58,7 +59,15 @@ public class ProblemService {
         }
 
         Problem problem = ProblemMapper.toEntity(dto, category, topics, user);
-        return ProblemMapper.toDto(problemRepository.save(problem));
+
+        Problem saved = problemRepository.save(problem);
+
+        // 관리자가 만든 문제.
+        if (user == null) {
+            courseService.addCourse(saved);
+        }
+
+        return ProblemMapper.toDto(saved);
     }
 
     public List<ProblemSimpleResponse> findAll() {

--- a/src/main/java/code/rice/bowl/spaghetti/service/TodayProblemService.java
+++ b/src/main/java/code/rice/bowl/spaghetti/service/TodayProblemService.java
@@ -2,9 +2,7 @@ package code.rice.bowl.spaghetti.service;
 
 import code.rice.bowl.spaghetti.dto.problem.ProblemDetailResponse;
 import code.rice.bowl.spaghetti.dto.user.UserTodayProblemResponse;
-import code.rice.bowl.spaghetti.entity.Problem;
-import code.rice.bowl.spaghetti.entity.TodayProblem;
-import code.rice.bowl.spaghetti.entity.User;
+import code.rice.bowl.spaghetti.entity.*;
 import code.rice.bowl.spaghetti.exception.NotFoundException;
 import code.rice.bowl.spaghetti.mapper.ProblemMapper;
 import code.rice.bowl.spaghetti.repository.TodayProblemRepository;
@@ -15,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +24,10 @@ public class TodayProblemService {
     private final UserService userService;
     private final CourseService courseService;
 
+    // 오늘의 문제로 코스 문제와 AI 문제 개수 설정.
+    private final static long COURSE_PROBLEM_CNT = 1;
+    private final static long AI_PROBLEM_CNT = 3;
 
-    private final long cnt = 1;
     /**
      * 오늘 문제에 대하여 제출 여부를 설정함.
      *
@@ -38,7 +39,17 @@ public class TodayProblemService {
         TodayProblem todayProblem = todayProblemRepository.findByUser_UserIdAndProblem_ProblemId(userId, problemId)
                 .orElseThrow(() -> new NotFoundException("not today problem"));
 
+        // 해당 문제 ID에 대하여
         todayProblem.setSubmitYN(true);
+
+        // 해당 문제의 생성자 확인.
+        Problem p = todayProblem.getProblem();
+
+        // AI가 만든 문제인 경우.
+        // 제출 기록이 있으므로 NotSolve 테이블에서 삭제.
+        if (p.getUser() != null) {
+            todayProblem.getUser().getNotSolveAiProblems().removeIf(c -> c.getProblem().equals(p));
+        }
 
 //        todayProblemRepository.save(todayProblem);
     }
@@ -104,7 +115,7 @@ public class TodayProblemService {
 
         // 모든 문제를 풀었으면 자동으로 해당 삭제.
         user.getTodayProblems().clear();
-        user.setCourseId(user.getCourseId() + cnt);
+        user.setCourseId(user.getCourseId() + COURSE_PROBLEM_CNT);
 
         return true;
     }
@@ -115,8 +126,15 @@ public class TodayProblemService {
         long start = user.getCourseId();
         List<TodayProblem> userProblems = new ArrayList<>();
 
-        for (long i = start; i < start + cnt; i++) {
-            Problem p = courseService.getCourse(i).getProblem();
+        // 코스 문제 가져오기.
+        for (long i = start; i < start + COURSE_PROBLEM_CNT; i++) {
+            Optional<Course> course = courseService.getCourseNullable(i);
+
+            // 코스가 존재 X -> 모든 코스 문제를 풀었음을 의미.
+            if (course.isEmpty())
+                break;
+
+            Problem p = course.get().getProblem();
 
             // AI가 생성한 문제(user != null)는 오늘 문제에 포함하지 않음
             if (p.getUser() != null) {
@@ -129,6 +147,19 @@ public class TodayProblemService {
                     .build());
         }
 
+        // 사용자가 만든 문제 중에서 AI 문제를 가져옴.
+        List<NotSolveProblem> aiNotSolve = user.getNotSolveAiProblems();
+
+        if (!aiNotSolve.isEmpty()) {
+            for (int i = 0; i < Math.min(AI_PROBLEM_CNT, aiNotSolve.size()); i++) {
+                userProblems.add(TodayProblem.builder()
+                        .user(user)
+                        .problem(aiNotSolve.get(i).getProblem())
+                        .build());
+            }
+        }
+
+        // 최종 데이터를 테이블에 추가.
         todayProblemRepository.saveAll(userProblems);
         return userProblems;
     }

--- a/src/main/java/code/rice/bowl/spaghetti/service/UserProblemHistoryService.java
+++ b/src/main/java/code/rice/bowl/spaghetti/service/UserProblemHistoryService.java
@@ -15,9 +15,25 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class UserProblemHistoryService {
 
+    private final UserService userService;
+
     private final UserProblemHistoryRepository historyRepository;
 
-    public List<UserProblemHistoryResponse> getHistoriesByUserId(Long userId) {
+    /**
+     * 사용자 이메일 바탕으로 사용자 제출 기록 조회.
+     * @param email 사용자 이메일
+     * @return  제출 기록.
+     */
+    public List<UserProblemHistoryResponse> getHistoriesByUser(String email) {
+        return getHistoriesByUser(userService.getUser(email).getUserId());
+    }
+
+    /**
+     * 사용자 아이디 바탕으로 사요자 제출 기록 조회.
+     * @param userId 사용자 id
+     * @return  제출 기록.
+     */
+    public List<UserProblemHistoryResponse> getHistoriesByUser(Long userId) {
         return historyRepository.findByUserUserId(userId).stream()
                 .map(UserProblemHistoryMapper::toDto)
                 .collect(Collectors.toList());

--- a/src/main/java/code/rice/bowl/spaghetti/utils/QuestionType.java
+++ b/src/main/java/code/rice/bowl/spaghetti/utils/QuestionType.java
@@ -1,0 +1,31 @@
+package code.rice.bowl.spaghetti.utils;
+
+
+import code.rice.bowl.spaghetti.exception.InvalidRequestException;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum QuestionType {
+    MULTIPLE_CHOICE("multiple_choice"),
+    SHORT_ANSWER("short_answer"),
+    TURE_FALSE("ture_false");
+
+    @JsonValue
+    private final String value;
+
+    @JsonCreator
+    public static QuestionType toType(String value) {
+        for (QuestionType data: values()) {
+            if (data.value.equalsIgnoreCase(value))
+                return data;
+        }
+
+        throw new InvalidRequestException("invalid QuestionType : " + value);
+    }
+}


### PR DESCRIPTION
- 사용자가 안 푼 AI가 생성한 문제를 저장한 테이블(NotSolveProblem) 추가.
- 문제 제출 시 AI 문제인 경우 NotSolveProblem에서 삭제하는 로직 추가.
- 문제 생성 시 관리가 만든 문제인 경우 courses 테이블에 들어가도록 로직 추가.
- QuestionType을 기존 Problem의 Inner class 에서 utils 외부로 분리.
- QuestionType 구조 수정.
- 제출 로그를 볼 수 있도록 crud에서 분리 시킴.